### PR TITLE
Multiple small improvements

### DIFF
--- a/lxc-top.rb
+++ b/lxc-top.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'ubygems'
 require 'terminal-table/import'
 


### PR DESCRIPTION
(1) cgroup path update (/sys/fs/cgroups);
(2) clear screen before each iteration;
(3) drop all the ancient records like temporary cgroup
    data and stopped/destroyed containers;
(4) signal handling to avoid the ugly exception
    when exitting via ^C interrupt;
